### PR TITLE
Run `apt update` after adding repo on jammy

### DIFF
--- a/inst/scripts/add_cranapt_jammy.sh
+++ b/inst/scripts/add_cranapt_jammy.sh
@@ -14,6 +14,7 @@ apt install --yes --no-install-recommends wget ca-certificates
 wget -q -O- https://eddelbuettel.github.io/r2u/assets/dirk_eddelbuettel_key.asc \
     | tee -a /etc/apt/trusted.gpg.d/cranapt_key.asc
 echo "deb [arch=amd64] https://dirk.eddelbuettel.com/cranapt jammy main" > /etc/apt/sources.list.d/cranapt.list
+apt update
 
 ## Third: ensure current R is used (could use Launchpad source or edd PPA too)
 wget -q -O- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc \


### PR DESCRIPTION
I was following the steps in `add_cranapt_jammy.sh` to setup r2u in a GitHub Actions build. Strangely it was installing way too many R packages, which I fixed by running `apt update`. This step is already included in `add_cranapt_focal.sh`, so I copied it to the jammy script.